### PR TITLE
Add automatic module name for runtime jar (#1)

### DIFF
--- a/runtime/build.gradle
+++ b/runtime/build.gradle
@@ -11,3 +11,9 @@ java {
     withJavadocJar()
     withSourcesJar()
 }
+
+tasks.jar {
+    manifest {
+        attributes("Automatic-Module-Name": "dev.vankka.dependencydownload.runtime")
+    }
+}


### PR DESCRIPTION
This commit fix the issue https://github.com/Vankka/DependencyDownload/issues/1 by add in manifest the module name.
This change keep the compatibility with non modular system, but add compatibility with modular system.
Now, we can add "requires" in module-info.java for this libraries