### PR TITLE
Add module name for common and fix modular run

### DIFF
--- a/common/build.gradle
+++ b/common/build.gradle
@@ -1,3 +1,9 @@
 dependencies {
     compileOnlyApi 'org.jetbrains:annotations:22.0.0'
 }
+
+tasks.jar {
+    manifest {
+        attributes("Automatic-Module-Name": "dev.vankka.dependencydownload.common")
+    }
+}

--- a/common/src/main/java/dev/vankka/dependencydownload/common/util/HashUtil.java
+++ b/common/src/main/java/dev/vankka/dependencydownload/common/util/HashUtil.java
@@ -1,4 +1,4 @@
-package dev.vankka.dependencydownload.util;
+package dev.vankka.dependencydownload.common.util;
 
 import java.io.File;
 import java.io.FileInputStream;

--- a/gradle-plugin/src/main/java/dev/vankka/dependencydownload/task/GenerateDependencyDownloadResourceTask.java
+++ b/gradle-plugin/src/main/java/dev/vankka/dependencydownload/task/GenerateDependencyDownloadResourceTask.java
@@ -2,7 +2,7 @@ package dev.vankka.dependencydownload.task;
 
 import dev.vankka.dependencydownload.DependencyDownloadGradlePlugin;
 import dev.vankka.dependencydownload.relocation.Relocation;
-import dev.vankka.dependencydownload.util.HashUtil;
+import dev.vankka.dependencydownload.common.util.HashUtil;
 import org.gradle.api.Action;
 import org.gradle.api.DefaultTask;
 import org.gradle.api.Task;

--- a/runtime/src/main/java/dev/vankka/dependencydownload/DependencyManager.java
+++ b/runtime/src/main/java/dev/vankka/dependencydownload/DependencyManager.java
@@ -8,7 +8,7 @@ import dev.vankka.dependencydownload.relocation.JarRelocatorHelper;
 import dev.vankka.dependencydownload.relocation.Relocation;
 import dev.vankka.dependencydownload.repository.Repository;
 import dev.vankka.dependencydownload.util.ExceptionalConsumer;
-import dev.vankka.dependencydownload.util.HashUtil;
+import dev.vankka.dependencydownload.common.util.HashUtil;
 
 import javax.net.ssl.HttpsURLConnection;
 import java.io.*;


### PR DESCRIPTION
I have add module name for common module, because this module is need by runtime module. To do that, I must modify the package (else there are conflict).
The new name is dev.vankka.dependencydownload.common.util (I have add common)