### PR TITLE
Fix classifier not being applied in Dependency#getFileName

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ This would generate two files `runtimeDownloadOnly.txt` and `runtimeDownload.txt
 
 ### Loading dependencies from a plugin generated file
 ```java
-DependecyManager manager = new DependencyManager();
+DependencyManager manager = new DependencyManager();
 manager.loadFromResource(getClass().getResource("runtimeDownloadOnly.txt"));
 ```
 
@@ -117,7 +117,7 @@ processResources.dependsOn generateJarRelocatorResource
 ```
 
 ```java
-DependecyManager manager = new DependencyManager();
+DependencyManager manager = new DependencyManager();
 manager.loadFromResource(getClass().getResource("jarRelocator.txt"));
 
 Executor executor = Executors.newCachedThreadPool(2);

--- a/runtime/src/main/java/dev/vankka/dependencydownload/dependency/Dependency.java
+++ b/runtime/src/main/java/dev/vankka/dependencydownload/dependency/Dependency.java
@@ -75,7 +75,8 @@ public interface Dependency {
      */
     @NotNull
     default String getFileName() {
-        return getArtifactId() + '-' + getVersion() + ".jar";
+        String classifier = getClassifier();
+        return getArtifactId() + '-' + getVersion() + (classifier != null ? '-' + classifier : "") + ".jar";
     }
 
     /**


### PR DESCRIPTION
When the https://github.com/Vankka/DependencyDownload/commit/be26d4ca70c0087667a7090a0e94bc92cd6b777e commit was written, a method was missed. I have just correct them.